### PR TITLE
Make tracking calls with event name for easier debugging

### DIFF
--- a/VastClient/VastClient/VastClient.swift
+++ b/VastClient/VastClient/VastClient.swift
@@ -21,11 +21,18 @@ public struct VastClientOptions {
 }
 
 public class VastClient {
+    
+    public static var trackingLogOutput: ((String, [URL]) -> ())? = nil
 
     private let options: VastClientOptions
 
     public init(options: VastClientOptions = VastClientOptions()) {
         self.options = options
+        #if DEBUG
+        VastClient.trackingLogOutput = { string, urls in
+            print("VastClient log: \(string), \(urls.debugDescription)")
+        }
+        #endif
     }
     
     public func parseVast(withContentsOf url: URL, completion: @escaping (VastModel?, Error?) -> ()) {

--- a/VastClient/VastClient/VastClient.swift
+++ b/VastClient/VastClient/VastClient.swift
@@ -28,11 +28,6 @@ public class VastClient {
 
     public init(options: VastClientOptions = VastClientOptions()) {
         self.options = options
-        #if DEBUG
-        VastClient.trackingLogOutput = { string, urls in
-            print("VastClient log: \(string), \(urls.debugDescription)")
-        }
-        #endif
     }
     
     public func parseVast(withContentsOf url: URL, completion: @escaping (VastModel?, Error?) -> ()) {

--- a/VastClient/VastClient/models/TrackingCreative.swift
+++ b/VastClient/VastClient/models/TrackingCreative.swift
@@ -35,10 +35,4 @@ extension TrackingCreative {
         self.midpoint = ceil(duration * 0.5)
         self.thirdQuartile = ceil(duration * 0.75)
     }
-
-    func callTrackingUrls(_ urls: [URL]) {
-        urls.forEach { url in
-            makeRequest(withUrl: url)
-        }
-    }
 }

--- a/VastClient/VastClient/models/VMAP/VMAPAdBreak.swift
+++ b/VastClient/VastClient/models/VMAP/VMAPAdBreak.swift
@@ -60,21 +60,4 @@ extension VMAPAdBreak {
         self.timeOffset = timeOffset
         self.repeatAfter = repeatAfter
     }
-    
-    public func trackEvent(withType type: VMAPTrackingEventType) {
-        trackingEvents.filter { $0.event == type }
-            .forEach { event in
-                guard let url = event.url else { return }
-                print("tracking event of type: \(type), url: \(url.absoluteString)")
-                makeRequest(withUrl: url)
-            }
-    }
-    
-    public func trackEvents(withUrls urls: [URL]) {
-        urls.forEach { url in
-            print("tracking event of type: \(VMAPTrackingEventType.breakEnd), url: \(url.absoluteString)")
-            makeRequest(withUrl: url)
-        }
-    }
-
 }

--- a/VastClient/VastClient/models/XML schema/VastViewableImpression.swift
+++ b/VastClient/VastClient/models/XML schema/VastViewableImpression.swift
@@ -17,7 +17,7 @@ struct VastViewableImpressionElements {
     static let viewUndetermined = "ViewUndetermined"
 }
 
-public enum VastViewableImpressionType {
+public enum VastViewableImpressionType: String {
     case viewable
     case notViewable
     case viewUndetermined

--- a/VastClient/VastClient/parsers/VastXMLParser.swift
+++ b/VastClient/VastClient/parsers/VastXMLParser.swift
@@ -82,9 +82,8 @@ class VastXMLParser: NSObject {
         }
 
         if !vm.errors.isEmpty, vm.ads.count == 0 {
-            vm.errors.forEach { error in
-                makeRequest(withUrl: error.withErrorCode(VastErrorCodes.noAdsVastResponse))
-            }
+            let urls = vm.errors.compactMap { $0.withErrorCode(VastErrorCodes.noAdsVastResponse) }
+            track(urls: urls, eventName: "ERROR NO ADS")
         }
         return vm
     }

--- a/VastClient/VastClient/utils/Tracking.swift
+++ b/VastClient/VastClient/utils/Tracking.swift
@@ -1,5 +1,5 @@
 //
-//  http.swift
+//  Tracking.swift
 //  VastClient
 //
 //  Created by John Gainfort Jr on 5/15/18.
@@ -8,21 +8,34 @@
 
 import Foundation
 
-func makeRequest(withUrl url: URL) {
+func track(url: URL, eventName: String? = nil) {
+    track(urls: [url], eventName: eventName)
+}
+
+func track(urls: [URL], eventName: String? = nil) {
+    urls.forEach{ makeRequest(withUrl: $0) }
+    if let eventName = eventName {
+        VastClient.trackingLogOutput?(eventName, urls)
+    } else {
+        VastClient.trackingLogOutput?("UNKNOWN", urls)
+    }
+}
+
+private func makeRequest(withUrl url: URL) {
     let request = URLRequest(url: url)
     let config = URLSessionConfiguration.default
     let session = URLSession(configuration: config)
 
     let task = session.dataTask(with: request) {(data, response, error) in
+        #if DEBUG
         DispatchQueue.global().async {
-            #if DEBUG
-            print("Completed request: \(request.debugDescription)")
             if let error = error {
                 print("Request \(request.debugDescription), finished with error: \(error)")
                 return
             }
-            #endif
+            print("Completed request: \(request.debugDescription)")
         }
+        #endif
     }
 
     task.resume()


### PR DESCRIPTION
Make all tracking calls via function with specified event type. This is necessary for easier debugging of the events being tracked.

Also, shorten most of the repetitive code in tracker.