### PR TITLE
encode URL string

### DIFF
--- a/Sources/VastClient/parsers/VastXMLParser.swift
+++ b/Sources/VastClient/parsers/VastXMLParser.swift
@@ -371,7 +371,7 @@ extension VastXMLParser: XMLParserDelegate {
                     currentVideoClick = nil
                 }
             case CreativeLinearElements.tracking, CompanionElements.trackingevents, CreativeNonLinearAdsElements.tracking:
-                currentTrackingEvent?.url = URL(string: currentContent)
+                currentTrackingEvent?.url = URL(string: currentContent.encoded)
                 if let trackingEvent = currentTrackingEvent {
                     if currentCompanionCreative != nil {
                         currentCompanionCreative?.trackingEvents.append(trackingEvent)


### PR DESCRIPTION
Tracking events are not being tracked from time to time. 
We found out that if the URL has a Pipe symbol "|"  the method **URL(string:)** returns nil, so the tracking events are lost.
To fix that, the string needs to be encoded.
